### PR TITLE
Add configuration folders as deb conffiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ def generate_distro_tasks = { dist, gPackageName, gInputFile, gVersion, gRelease
             into '/usr/share/openhab2'
             exclude 'conf/**'
             exclude 'userdata/**'
-            exclude 'runtime/karaf/bin/oh2_dir_layout'
+            exclude 'runtime/bin/oh2_dir_layout'
             exclude 'start.bat'
             exclude 'start_debug.bat'
         }
@@ -124,17 +124,19 @@ def generate_distro_tasks = { dist, gPackageName, gInputFile, gVersion, gRelease
             include 'conf/**'
             eachFile { details ->
                 def pkgPath = details.path - 'conf'
-                details.path = pkgPath 
+                details.path = pkgPath
+                configurationFile(details.path)
             }
         }
         from(tar){
             fileType CONFIG | NOREPLACE
-            eachFile { details ->
-                def pkgPath = details.path - 'userdata'
-                details.path = pkgPath 
-            }
             into '/var/lib/openhab2'
             include 'userdata/**'
+            eachFile { details ->
+                def pkgPath = details.path - 'userdata'
+                details.path = pkgPath
+                configurationFile(details.path)
+            }
         }
         from(debResourcesDir + 'bin/oh2_dir_layout'){
             fileMode 0775

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,6 @@ def generate_distro_tasks = { dist, gPackageName, gInputFile, gVersion, gRelease
             exclude 'start_debug.bat'
         }
         from(tar){
-            fileType CONFIG | NOREPLACE
             into '/etc/openhab2'
             include 'conf/**'
             eachFile { details ->
@@ -129,7 +128,6 @@ def generate_distro_tasks = { dist, gPackageName, gInputFile, gVersion, gRelease
             }
         }
         from(tar){
-            fileType CONFIG | NOREPLACE
             into '/var/lib/openhab2'
             include 'userdata/**'
             eachFile { details ->


### PR DESCRIPTION
`CONFIG | NOREPLACE` doesn't seem to be behaving correctly, and the current implentation will always overwrite conf files. If we use confgurationFile() then Debian upgrades become aware of them.

I've tested this from gradle build to gradle build AND from cloudbees to gradle build and it looks like conf file pathing is the same in each with this change. Just in case I've missed something, please test this as well.

(Also spotted another ./karaf/bin instead of ./bin so updated accordingly)

Signed-off-by: Ben Clark <ben@benjyc.uk>