### PR TITLE
Updated and included init.d config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,12 @@ def generate_distro_tasks = { dist, gPackageName, gInputFile, gVersion, gRelease
             permissionGroup 'root'
             into '/usr/lib/systemd/system'
         }
+        from(debResourcesDir + 'etc/init.d/openhab2'){
+            fileMode 0775
+            user 'root'
+            permissionGroup 'root'
+            into '/etc/init.d/'
+        }
         from(tar){
             into '/usr/share/openhab2'
             exclude 'conf/**'

--- a/resources/deb/etc/init.d/openhab2
+++ b/resources/deb/etc/init.d/openhab2
@@ -71,15 +71,38 @@ fi
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh
 
+# Check to see if openHAB is currently running
+findpid() {
+    ps aux --sort=start_time | grep openhab.*java | grep -v grep | awk '{print $2}' | tail -1
+}
+
+EXISTINGPID=$(findpid)
+
 case "$1" in
   start)
         log_daemon_msg "Starting $DESC" "$NAME"
-        #${OPENHAB_INST_DIR}/bin/setpermissions.sh > /dev/null
-        if start-stop-daemon --start --quiet --pidfile $PIDFILE -c "${USER_AND_GROUP}" --umask 002 --background --make-pidfile --chdir ${OPENHAB_DIR} \
-                --oknodo --exec /usr/share/openhab2/runtime/bin/start
+        # OpenHAB may be shutting down if a process still exists but there's no PID file.
+        if [ -z "$EXISTINGPID" ] || [ ! -f $PIDFILE ];
         then
-            log_end_msg 0
+            if start-stop-daemon --start --quiet --pidfile $PIDFILE -c "${USER_AND_GROUP}" \
+                    --umask 002 --background --chdir ${OPENHAB_DIR} \
+                    --oknodo --exec /usr/share/openhab2/runtime/bin/start
+            then
+                timeout=0
+                # The correct process is only available once the wrapper scripts have finished.
+                until [ $timeout -eq 5 ] || [ ! -z "$pid"  ];
+                do
+                    sleep 1
+                    pid=$(findpid)
+                    timeout=$((timeout+1))
+                done
+                echo "$pid" > $PIDFILE
+                log_end_msg 0
+            else
+                log_end_msg 1
+            fi
         else
+            echo -n "Error: OpenHAB is already running with PID: $EXISTINGPID!"
             log_end_msg 1
         fi
         ;;
@@ -104,7 +127,7 @@ case "$1" in
             then
                 log_end_msg 0
             else
-               log_end_msg 1
+                log_end_msg 1
             fi
         else
             log_end_msg 1


### PR DESCRIPTION
Added init.d to the gradle build for Linux init systems based on sysVinit.

Also prevented more than one instance from running "start" multiple times and implemented a simple mechanism to keep /var/run/openhab.pid up to date. 

This _should not_ affect Linux systems based on systemd.

Resolves https://github.com/openhab/openhab-distro/issues/328

Signed-off-by: Ben Clark <ben@benjyc.uk>