### PR TITLE
Set /etc/default/openhab2 as a conffile.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ ospackage {
     postInstall file(resourcesDir + 'deb/control-runtime/postinst')
     preUninstall file(resourcesDir + 'deb/control-runtime/prerm')
     postUninstall file(resourcesDir + 'deb/control-runtime/postrm')
+    
+    configurationFile('/etc/default/openhab2')
 
     requires('adduser')
 


### PR DESCRIPTION
As it is in the the openhab-distro repo otherwise we'd be overwriting custom parameters.

Signed-off-by: Ben Clark <ben@benjyc.uk>