### PR TITLE
Prevent init.d script from running on RPM.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,8 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
 
                 if (pType == 'Deb') {
                     requires('adduser')
+                } else {
+                    requires('systemd')
                 }
 
                 FileTree tar = tarTree(gInputFile)
@@ -226,11 +228,13 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
                     permissionGroup 'root'
                     into '/usr/lib/systemd/system'
                 }
-                from(debResourcesDir + 'etc/init.d/openhab2'){
-                    fileMode 0775
-                    user 'root'
-                    permissionGroup 'root'
-                    into '/etc/init.d/'
+                if (pType == 'Deb') {
+                    from(debResourcesDir + 'etc/init.d/openhab2'){
+                        fileMode 0775
+                        user 'root'
+                        permissionGroup 'root'
+                        into '/etc/init.d/'
+                    }
                 }
                 from(tar){
                     into '/usr/share/openhab2'

--- a/resources/deb/etc/init.d/openhab2
+++ b/resources/deb/etc/init.d/openhab2
@@ -38,12 +38,20 @@ log_end_msg () {
     return $val
 }
 
+log_success_msg () {
+    echo " OK!"
+}
+
+log_failure_msg () {
+    echo " failed!"
+}
+
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
 # and status_of_proc is working.
 
 if  [ -r /lib/lsb/init-functions ]; then
     . /lib/lsb/init-functions
-else
+elif [ -r /etc/init.d/functions ]; then
     . /etc/init.d/functions
 fi
 
@@ -133,7 +141,7 @@ dostop() {
     # In case the pid in the pidfile was wrong, also kill/stop existing process
     killwaitpid $EXISTINGPID
     log_end_msg 0
-      return 0 
+      return 0
   else
     log_end_msg 1
     return 1
@@ -162,14 +170,6 @@ dostart() {
       log_end_msg 0
       return 0
     else
-      if start_daemon -p $PIFILE /usr/share/openhab2/runtime/bin/start
-      then
-          log_end_msg 0
-          return 0
-      else
-          log_end_msg 1
-          return 1
-      fi
       log_end_msg 1
       return 1
     fi

--- a/resources/deb/etc/init.d/openhab2
+++ b/resources/deb/etc/init.d/openhab2
@@ -24,12 +24,33 @@ SCRIPTNAME=/etc/init.d/$NAME
 SETOWNER=yes
 
 # Define LSB log_* functions.
+log_daemon_msg () {
+    echo $@
+}
+
+log_end_msg () {
+    val=$1
+    if [ $val -eq 0 ]; then
+        log_success_msg ""
+    else
+        log_failure_msg ""
+    fi
+    return $val
+}
+
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
 # and status_of_proc is working.
-. /lib/lsb/init-functions
+
+if  [ -r /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+else
+    . /etc/init.d/functions
+fi
 
 # Read configuration variable file if it is present
-[ -r /etc/default/openhab2 ] && . /etc/default/openhab2
+if [ -r /etc/default/openhab2 ]; then
+    . /etc/default/openhab2
+fi
 
 OPENHAB_CONF_DIR="/etc/openhab2"
 OPENHAB_DIR="/usr/share/openhab2"
@@ -69,7 +90,9 @@ if ! getent group "${GROUP}" > /dev/null 2>&1; then
 fi
 
 # Load the VERBOSE setting and other rcS variables
-. /lib/init/vars.sh
+if [ -r /lib/init/vars.sh ]; then
+    . /lib/init/vars.sh
+fi
 
 # Check to see if openHAB is currently running
 findpid() {
@@ -81,6 +104,7 @@ EXISTINGPID=$(findpid)
 # Kill/Wait pid
 killwaitpid() {
   kpid=$1
+  echo -n "Waiting for openHAB to stop"
   while kill -0 $kpid 2> /dev/null ; do
     if [ $timeout -eq 60 ]; then
       # finally kill the process if timeout is reached
@@ -88,7 +112,7 @@ killwaitpid() {
       kill -9 $kpid
       break
     else
-      echo "Waiting for the process to stop"
+      echo -n "."
       timeout=$((timeout+1))
       sleep 1
     fi
@@ -138,6 +162,14 @@ dostart() {
       log_end_msg 0
       return 0
     else
+      if start_daemon -p $PIFILE /usr/share/openhab2/runtime/bin/start
+      then
+          log_end_msg 0
+          return 0
+      else
+          log_end_msg 1
+          return 1
+      fi
       log_end_msg 1
       return 1
     fi


### PR DESCRIPTION
Deb and RPM init daemons are simply incompatible. We should only allow RPM systemd processes until we can make a separate init script for RHEL systems.

Additionally, this PR defines some simple placeholders for the special OSes that can use dpkg but don't have the same daemon logging functions.

Signed-off-by: Ben Clark <ben@benjyc.uk>