### PR TITLE
Systemd service should use /bin/karaf instead of start.sh

### DIFF
--- a/resources/etc/default/openhab2
+++ b/resources/etc/default/openhab2
@@ -29,3 +29,9 @@ EXTRA_JAVA_OPTS=""
 #
 #OPENHAB_USER=openhab
 #OPENHAB_GROUP=openhab
+#
+# The Karaf startmode for the openHAB runtime. Only available for systemctl/systemd systems.
+# Defaults to daemon when unset here. Multiple options can be used without quotes. 
+# debug increases log output. daemon launches the Karaf/openHAB processes. 
+#
+#OPENHAB_STARTMODE=debug

--- a/resources/systemd/openhab2.service
+++ b/resources/systemd/openhab2.service
@@ -11,15 +11,22 @@ Environment=OPENHAB_CONF=/etc/openhab2
 Environment=OPENHAB_RUNTIME=/usr/share/openhab2/runtime
 Environment=OPENHAB_USERDATA=/var/lib/openhab2
 Environment=OPENHAB_LOGDIR=/var/log/openhab2
+Environment=OPENHAB_STARTMODE=daemon
 EnvironmentFile=-/etc/default/openhab2
+
 User=openhab
 Group=openhab
+
 WorkingDirectory=/usr/share/openhab2
-ExecStart=/usr/share/openhab2/start.sh server
-ExecStop=/usr/share/openhab2/runtime/bin/stop
-# Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)
-TimeoutStopSec=120
+ExecStart=/usr/share/openhab2/runtime/bin/karaf $OPENHAB_STARTMODE
+ExecStop=/usr/share/openhab2/runtime/bin/karaf stop
+
+SuccessExitStatus=0 143
+RestartSec=5
 Restart=on-failure
+TimeoutStopSec=120
+
+LimitNOFILE=102642
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #70 

Signed-off-by: Ben Clark <ben@benjyc.uk>