### PR TITLE
Stop using ospackage template for control files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,10 +198,10 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
           into 'usr/share/openhab2/addons'
         }
       } else {
-        preInstall file('resources/control-runtime/preinst')
-        postInstall file('resources/control-runtime/postinst')
-        preUninstall file('resources/control-runtime/prerm')
-        postUninstall file('resources/control-runtime/postrm')
+        preInstallFile file('resources/control-runtime/preinst')
+        postInstallFile file('resources/control-runtime/postinst')
+        preUninstallFile file('resources/control-runtime/prerm')
+        postUninstallFile file('resources/control-runtime/postrm')
 
         configurationFile('/etc/default/openhab2')
         configurationFile('/etc/profile.d/openhab2.sh')

--- a/build.gradle
+++ b/build.gradle
@@ -198,11 +198,19 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
           into 'usr/share/openhab2/addons'
         }
       } else {
-        preInstallFile file('resources/control-runtime/preinst')
-        postInstallFile file('resources/control-runtime/postinst')
-        preUninstallFile file('resources/control-runtime/prerm')
-        postUninstallFile file('resources/control-runtime/postrm')
-
+      
+        if (pType == 'Rpm') {
+          preInstall file('resources/control-runtime/preinst')
+          postInstall file('resources/control-runtime/postinst')
+          preUninstall file('resources/control-runtime/prerm')
+          postUninstall file('resources/control-runtime/postrm')
+        } else {
+          preInstallFile file('resources/control-runtime/preinst')
+          postInstallFile file('resources/control-runtime/postinst')
+          preUninstallFile file('resources/control-runtime/prerm')
+          postUninstallFile file('resources/control-runtime/postrm')
+        }
+        
         configurationFile('/etc/default/openhab2')
         configurationFile('/etc/profile.d/openhab2.sh')
 


### PR DESCRIPTION
Never thought to check this earlier, but it seems that use of preInstall postInstall etc is appending to a template from ospackage, we certainly don't want that as it encapsulates everything in our scripts in the configure stage...

This would not have changed anything in `prerm` or `postrm`, just `preinstall` and `postinstall` but requires extensive testing nonetheless.

Signed-off-by: Ben Clark <ben@benjyc.uk>