### PR TITLE
Add distribution task for stable builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ ARTIFACTORY_ORG = ARTIFACTORY_ORG ?: 'openhab'
 ARTIFACTORY_REPO = ARTIFACTORY_REPO ?: 'openhab-linuxpkg'
 ARTIFACTORY_GPG_KEY_ID = ARTIFACTORY_GPG_KEY_ID ?: 'A224060A' 
 
+def BINTRAY_USER    = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.env.BINTRAY_USER
+def BINTRAY_KEY     = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.env.BINTRAY_API_KEY
+
 def OHVersion = project.hasProperty('openHABVersion') ? project.property('openHABVersion') : System.env.OPENHAB_VERSION
 def OHTestingVersion = project.hasProperty('openHABTestingVersion') ? project.property('openHABTestingVersion') : System.env.OPENHAB_TESTING_VERSION
 def OHSnapVersion = project.hasProperty('openHABSnapshotVersion') ? project.property('openHABSnapshotVersion') : System.env.OPENHAB_SNAPSHOT_VERSION
@@ -461,11 +464,25 @@ task removeOlderVersions(type:Exec) {
   }
 }
 
-def BINTRAY_USER    = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.env.BINTRAY_USER
-def BINTRAY_KEY     = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.env.BINTRAY_API_KEY
+task deployToBintray(type:Exec) {
+  def distributeRepo = 'openhab-linuxpkg-distribution'
+  def distributeURL = "https://openhab.jfrog.io/${ARTIFACTORY_ORG}/api/distribute"
+
+  def aptPackagePath = "openhab-linuxpkg/pool/main/${OHVersion}/openhab2_${OHVersion}-${OHReleaseNumber}_all.deb"
+  def aptAddonPath = "openhab-linuxpkg/pool/main/${OHVersion}/openhab2-addons_${OHVersion}-${OHReleaseNumber}_all.deb"
+  def aptLegacyPath = "openhab-linuxpkg/pool/main/${OHVersion}/openhab2-addons-legacy_${OHVersion}-${OHReleaseNumber}_all.deb"
+
+  def rpmPackagePath = "openhab-linuxpkg-rpm/stable/${OHVersion}/openhab2-${OHVersion}-${OHReleaseNumber}.noarch.rpm"
+  def rpmAddonPath = "openhab-linuxpkg-rpm/stable/${OHVersion}/openhab2-addons-${OHVersion}-${OHReleaseNumber}.noarch.rpm"
+  def rpmLegacyPath = "openhab-linuxpkg-rpm/stable/${OHVersion}/openhab2-addons-legacy-${OHVersion}-${OHReleaseNumber}.noarch.rpm"
+
+  def artifactString = "[\"${aptPackagePath}\",\"${aptAddonPath}\",\"${aptLegacyPath}\",\"${rpmPackagePath}\",\"${rpmAddonPath}\",\"${rpmLegacyPath}\"]"
+
+  executable "curl"
+  args '-X', 'POST', '-H', "X-JFrog-Art-Api: ${ARTIFACTORY_KEY}", '-H', 'Content-Type: application/json', '-d', "{\"targetRepo\" : \"${distributeRepo}\", \"packagesRepoPaths\" : ${artifactString}, \"dryRun\" : \"true\" }", "${distributeURL}"
+}
 
 task calculateMetadata(type:Exec) {
      executable "curl"
      args "-X", "POST", "-H", "X-GPG-PASSPHRASE: ${ARTIFACTORY_GPG}", "-u${BINTRAY_USER}:${BINTRAY_KEY}", "https://api.bintray.com/calc_metadata/openhab/apt-repo2"
 }
-


### PR DESCRIPTION
Closes #88 

- Fetches the deb and rpm files on artifactory, which would have been created after the `buildRelease` task.
- Takes the artifact paths and sends them to artifactory's distribution repo, which I have setup to publish to our Bintray repos, it works out what the packages are and which version they are from the metadata.
- Currently setup as a dry run.

Signed-off-by: Ben Clark <ben@benjyc.uk>