### PR TITLE
Allow use of tilde in rpm versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,9 +181,6 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
       if (pType == 'Deb') { arch = "${OSPACKAGE_ARCH}" }
       release = gRelease
       packageName = gPackageName
-      if (pType == 'Rpm') {
-        gVersion = gVersion.replaceAll('~','.')
-      }
 
       version = gVersion
       distribution = topDist


### PR DESCRIPTION
The rpm package tool denied the use of tilde in versioning. This is no longer the case and we should match.

We should start doing this from 2.4.0 release onward to minimise sort errors, so will merge the change when that comes round.

Signed-off-by: Ben Clark <ben@benjyc.uk>