### PR TITLE
Introduce additional openhab2 service options file

### DIFF
--- a/resources/etc/init.d/deb/openhab2
+++ b/resources/etc/init.d/deb/openhab2
@@ -31,6 +31,11 @@ if [ -z "${OPENHAB_LOGDIR}" ];     then OPENHAB_LOGDIR="/var/log/openhab2"; fi
 if [ -z "${OPENHAB_USER}" ];       then OPENHAB_USER="openhab"; fi
 if [ -z "${OPENHAB_GROUP}" ];      then OPENHAB_GROUP="openhab"; fi
 
+# Override configuration variables from user file if it present
+if [ -r ${OPENHAB_CONF}/openhab2 ]; then
+  . ${OPENHAB_CONF}/openhab2
+fi
+
 export OPENHAB_HTTP_PORT
 export OPENHAB_HTTPS_PORT
 export OPENHAB_HOME


### PR DESCRIPTION
During distro update, default openhab2 (/etc/default/openhab2) service options file is easily/accidentally overwritten by the user and all manual configuration (e.g. EXTRA_JAVA_OPTS) are gone. Also if new parameters are introduced to default file, user should merge manual settings to new file, which can be cumbersome for many users. This PR introduce new user specific options file which will never be updated during distro update. As new file is placed to /etc/openhab2, it will be also part of the user backups. 

If this is accepted, I will update this PR also cover the rpm package.

Signed-off-by: Pauli Anttila pauli.anttila@gmail.com