### PR TITLE
Correct error in startup mode

### DIFF
--- a/resources/systemd/openhab2.service
+++ b/resources/systemd/openhab2.service
@@ -18,7 +18,7 @@ User=openhab
 Group=openhab
 
 WorkingDirectory=/usr/share/openhab2
-ExecStart=/usr/share/openhab2/runtime/bin/karaf $OPENHAB_STARTMODE
+ExecStart=/usr/share/openhab2/runtime/bin/karaf ${OPENHAB_STARTMODE}
 ExecStop=/usr/share/openhab2/runtime/bin/karaf stop
 
 SuccessExitStatus=0 143


### PR DESCRIPTION
Braces should be used in all variables inside the service file.

See: https://ask.fedoraproject.org/en/question/10474/why-systemd-is-not-loading-environment-file/

Signed-off-by: Ben Clark <ben@benjyc.uk>