### PR TITLE
bug correction in /etc/init.d/openhab2 ensuring the PID si correctly set in the pidfile

### DIFF
--- a/resources/etc/init.d/deb/openhab2
+++ b/resources/etc/init.d/deb/openhab2
@@ -118,7 +118,7 @@ fi
 
 # Check to see if openHAB is currently running
 findpid() {
-  ps aux --sort=start_time | grep "openhab2.*java" | grep -v grep | awk '{print $2}' | tail -1
+  COLUMNS=3000 ps aux --sort=start_time | grep "openhab2.*java" | grep -v grep | awk '{print $2}' | tail -1
 }
 
 EXISTINGPID=$(findpid)

--- a/resources/etc/init.d/deb/openhab2
+++ b/resources/etc/init.d/deb/openhab2
@@ -118,7 +118,7 @@ fi
 
 # Check to see if openHAB is currently running
 findpid() {
-  COLUMNS=3000 ps aux --sort=start_time | grep "openhab2.*java" | grep -v grep | awk '{print $2}' | tail -1
+  pgrep -f 'openhab2.*java'
 }
 
 EXISTINGPID=$(findpid)

--- a/resources/etc/init.d/rpm/openhab2
+++ b/resources/etc/init.d/rpm/openhab2
@@ -118,7 +118,7 @@ fi
 
 # Check to see if openHAB is currently running
 findpid() {
-  ps aux --sort=start_time | grep "openhab2.*java" | grep -v grep | awk '{print $2}' | tail -1
+  COLUMNS=3000 ps aux --sort=start_time | grep "openhab2.*java" | grep -v grep | awk '{print $2}' | tail -1
 }
 
 EXISTINGPID=$(findpid)

--- a/resources/etc/init.d/rpm/openhab2
+++ b/resources/etc/init.d/rpm/openhab2
@@ -118,7 +118,7 @@ fi
 
 # Check to see if openHAB is currently running
 findpid() {
-  COLUMNS=3000 ps aux --sort=start_time | grep "openhab2.*java" | grep -v grep | awk '{print $2}' | tail -1
+  pgrep -f 'openhab2.*java'
 }
 
 EXISTINGPID=$(findpid)


### PR DESCRIPTION
starting openhab from within the monit daemon results in an empty pidfile. This is systematic on my raspbian config. 
Debugging the issue shows that the findpid function indeed involves a grep "openhab2.*java" on the output of the 'ps aux' command that will not find a match unless there are enough characters to hold the long java command line output by the ps command. 
Solution: i prefixed the 'ps aux' with  'COLUMNS=3000' that ensures that it will be the case.

