### PR TITLE
re-added distro artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,15 @@ ospackage {
 
 def distributions = [
   [
+    "dist":        'openhab2-release',
+    "description": 'Linux installation package for openHAB 2.',
+    "debDist":     ['stable','testing','unstable'],
+    "packageName": 'openhab2',
+    "url":         "https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F${OHVersion}%2Fopenhab-${OHVersion}.tar.gz",
+    "path":        buildDir.getAbsolutePath() + '/' + "openhab-${OHVersion}.tar.gz",
+    "version":     "${OHVersion}",
+    "release":     "${OHReleaseNumber}"
+  ],[
     'dist':        'openhab2-addons-release',
     'description': 'Linux installation package for openHAB 2 addons.',
     'debDist':     ['stable','testing','unstable'],
@@ -99,6 +108,15 @@ def distributions = [
     'version':     "${OHVersion}",
     'release':     "${OHReleaseNumber}"
   ],[
+    "dist":        'openhab2-testing',
+    "description": 'Linux installation package for openHAB 2.',
+    "debDist":     ['testing'],
+    "packageName": 'openhab2',
+    "url":         "https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/${OHTestingVersion}/openhab-${OHTestingVersion}.tar.gz",
+    "path":        buildDir.getAbsolutePath() + '/' + "openhab-${OHTestingVersion}.tar.gz",
+    "version":     "${OHTestingVersion}",
+    "release":     "${OHReleaseNumber}"
+  ],[
     'dist':        'openhab2-addons-testing',
     'description': 'Linux installation package for openHAB 2 addons.',
     'debDist':     ['testing'],
@@ -116,6 +134,15 @@ def distributions = [
     'path':        buildDir.getAbsolutePath() + '/' + "openhab-addons-legacy-${OHTestingVersion}.kar",
     'version':     "${OHTestingVersion}",
     'release':     "${OHReleaseNumber}"
+  ],[
+    'dist':        'openhab2-snapshot',
+    'description': 'Linux installation package for openHAB 2.',
+    'debDist':     ['unstable'],
+    'packageName': 'openhab2',
+    'url':         "https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${OHSnapVersion}-SNAPSHOT.tar.gz",
+    'path':        buildDir.getAbsolutePath() + '/' + "openhab-${OHSnapVersion}-SNAPSHOT.tar.gz",
+    'version':     "${OHPackageSnapVersion}",
+    'release':     '1'
   ],[
     'dist':        'openhab2-addons-snapshot',
     'description': 'Linux installation package for openHAB 2 addons.',


### PR DESCRIPTION
As noticed/suggested in https://github.com/openhab/openhab-docker/issues/272#issuecomment-586647800, I revert the decision to not build any distro - people are used to the existing update process and even if the distro itself is identical to before, we can still publish a new binary of it, so that the existing processes keep working.

Signed-off-by: Kai Kreuzer <kai@openhab.org>