### PR TITLE
Stop tmp placeholders from being created on update (3.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,6 +335,7 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
           exclude 'userdata/etc/startup.properties'
           exclude 'userdata/etc/system.properties'
           exclude 'userdata/etc/version.properties'
+          exclude 'userdata/tmp/**'
           eachFile { details ->
             def pkgPath = details.path - 'userdata'
             details.path = pkgPath


### PR DESCRIPTION
Signed-off-by: Ben Clark <ben@benjyc.uk>