### PR TITLE
Fix typo of systemctl path

### DIFF
--- a/resources/control-runtime/prerm
+++ b/resources/control-runtime/prerm
@@ -32,7 +32,7 @@ stopOpenHAB() {
 }
 
 flagRestart() {
-  if [ -x /binsystemctl ] ; then
+  if [ -x /bin/systemctl ] ; then
     if /bin/systemctl status openhab2.service > /dev/null 2>&1; then
       touch ${RESTART_FLAG_FILE}
     fi


### PR DESCRIPTION
Simple typo, didn't come up during testing because `/etc/init.d/openhab2` existed which redirected to systemctl anyway.

#159/#163 changed this to correct (but broken) behaviour.

Fixes #172

Signed-off-by: Ben Clark <ben@benjyc.uk>