### PR TITLE
Fix typo of systemctl path (2.5.x)

### DIFF
--- a/resources/control-runtime/prerm
+++ b/resources/control-runtime/prerm
@@ -32,7 +32,7 @@ stopOpenHAB() {
 }
 
 flagRestart() {
-  if [ -x /binsystemctl ] ; then
+  if [ -x /bin/systemctl ] ; then
     if /bin/systemctl status openhab2.service > /dev/null 2>&1; then
       touch ${RESTART_FLAG_FILE}
     fi


### PR DESCRIPTION
See #173 

Signed-off-by: Ben Clark <ben@benjyc.uk>