### PR TITLE
Allow transfer of configuration over from OH2 to OH3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
           postInstall file('resources/control-runtime/postinst')
           preUninstall file('resources/control-runtime/prerm')
           postUninstall file('resources/control-runtime/postrm')
+          postTrans file('resources/control-runtime/posttrans')
         } else {
           preInstallFile file('resources/control-runtime/preinst')
           postInstallFile file('resources/control-runtime/postinst')

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ def generate_distro_tasks = { dist, gDescription, gPackageName, gInputFile, gVer
           requires('adduser')
         }
 
-        suggests('zulu-8 | zulu-embedded-8 | oracle-java8-installer |  openjdk-8-jdk-headless')
+        suggests('openjdk-11-jdk | openjdk-11-jre')
         recommends('zip')
         recommends('unzip')
 

--- a/resources/control-runtime/postinst
+++ b/resources/control-runtime/postinst
@@ -249,6 +249,8 @@ case "$1" in
         printf "${OPENHAB_TEXT} Previous 2.x install detected, making necessary changes"
         scanVersioningList "POST" "${OPENHAB_TEXT} Performing post-update tasks for version"
         scanVersioningList "MSG" "${OPENHAB_TEXT} Listing important changes for version"
+        find /var/lib/openhab/config/ -type f -name "*.config" -exec sed -i'.bak' 's|/var/lib/openhab2/|/var/lib/openhab/|g' {} \;
+        find /var/lib/openhab/config/ -type f -name "*.config" -exec sed -i'.bak' 's|/usr/share/openhab2/|/usr/share/openhab/|g' {} \;
         rm -f /var/lib/openhab/.copiedToOH3
       fi
 

--- a/resources/control-runtime/postinst
+++ b/resources/control-runtime/postinst
@@ -69,7 +69,7 @@ findpid() {
   if [ x"${USER_AND_GROUP}" != x ]; then
     OH_USER=$(echo "${USER_AND_GROUP}" | cut -d ":" -f 1)
   fi
-  ps aux -u "$OH_USER" --sort=start_time 2>/dev/null | grep openhab.*java | grep -v grep | awk '{print $2}' | tail -1
+  pgrep -f 'openhab.*java'
 }
 
 waitForStopFinished(){
@@ -119,9 +119,9 @@ restartIfFlagFileExists(){
 checkJava(){
   # Java must be at least version 8, check for this
   VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed -e 's/_.*//g; s/^1\.//g; s/\..*//g; s/-.*//g;')
-  if [ -z "$VERSION" ] || [ "${VERSION}" -lt "8" ]; then
-    printf "${OPENHAB_TEXT} WARNING: We were unable to detect Java 8 on your system. This is needed before openHAB can be started.\n" 
-    printf "${OPENHAB_TEXT} Please install the current version of Java 8 or check the openHAB documentation for details."
+  if [ -z "$VERSION" ] || [ "${VERSION}" -lt "11" ]; then
+    printf "${OPENHAB_TEXT} WARNING: We were unable to detect Java 11 on your system. This is needed before openHAB can be started.\n"
+    printf "${OPENHAB_TEXT} Please install the current version of Java 11 or check the openHAB documentation for details."
     echo ""
   fi
 }
@@ -147,6 +147,18 @@ runCommand() {
     param3="$(echo "$string" | awk -F';' '{print $4}')"
 
     case $command in
+      'DELETE')
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
     'MOVE')
       if [ -f "$param1" ]; then
         echo "  Moving:   From $param1 to $param2"
@@ -232,6 +244,14 @@ case "$1" in
     resetEnv
     if [ -z "$2" ] && [ "$1" != 2 ] ; then
       # this is a fresh installation
+      if [ -f /var/lib/openhab/.copiedToOH3 ]; then
+        oldVersion="2.9.9"
+        printf "${OPENHAB_TEXT} Previous 2.x install detected, making necessary changes"
+        scanVersioningList "POST" "${OPENHAB_TEXT} Performing post-update tasks for version"
+        scanVersioningList "MSG" "${OPENHAB_TEXT} Listing important changes for version"
+        rm -f /var/lib/openhab/.copiedToOH3
+      fi
+
       if [ -x /bin/systemctl ] ; then
         rm -f /etc/init.d/openhab
         printf "${OPENHAB_TEXT} Please use the following commands to launch openHAB on a system restart.\n"

--- a/resources/control-runtime/posttrans
+++ b/resources/control-runtime/posttrans
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Executed on RPM systems after all upgrading/removing is complete.
+#
+# Necessary for the special case of upgrading from OH2 to OH3
+#
+
+set -e
+
+unset OPENHAB_HTTP_PORT
+unset OPENHAB_HTTPS_PORT
+unset OPENHAB_HOME
+unset OPENHAB_CONF
+unset OPENHAB_RUNTIME
+unset OPENHAB_USERDATA
+unset OPENHAB_BACKUPS
+unset OPENHAB_LOGDIR
+unset OPENHAB_USER
+unset OPENHAB_GROUP
+
+if [ -r /etc/profile.d/openhab.sh ]; then
+  . /etc/profile.d/openhab.sh
+fi
+
+case "$1" in
+  1)
+    #On installation (of openhab package specifically)
+    OH_USER=openhab
+    OH_GROUP=openhab
+    if ! getent group "$OH_GROUP" > /dev/null 2>&1 ; then
+      groupadd --system "$OH_GROUP"
+    fi
+    if ! getent passwd "$OH_USER" > /dev/null 2>&1 ; then
+      useradd --system -g "$OH_GROUP"  \
+      --shell /bin/false \
+      --home /var/lib/openhab "$OH_USER"
+    fi
+    for pGroup in bluetooth tty dialout audio
+    do
+      if ! id -nG "$OH_USER" | grep -qw "$pGroup"; then
+        if getent group $pGroup > /dev/null 2>&1 ; then
+          usermod -a -G $pGroup $OH_USER
+        fi
+      fi
+    done
+    chown -R openhab:openhab "${OPENHAB_HOME:?}" "${OPENHAB_USERDATA:?}" "${OPENHAB_CONF:?}" "${OPENHAB_LOGDIR:?}"
+    ;;
+esac
+
+exit 0

--- a/resources/control-runtime/preinst
+++ b/resources/control-runtime/preinst
@@ -51,9 +51,34 @@ flagVersion() {
   fi
 }
 
+copyOH2toOH3(){
+  if [ -d /var/lib/openhab2 ] && [ ! -f /var/lib/openhab2/.copiedToOH3 ]; then
+    touch /var/lib/openhab2/.copiedToOH3
+    if [ -d /var/lib/openhab ]; then
+      /bin/cp -Rp /var/lib/openhab2/. /var/lib/openhab/
+    else
+      /bin/cp -Rp /var/lib/openhab2 /var/lib/openhab
+    fi
+  fi
+
+  if [ -d /etc/openhab2 ] && [ ! -f /etc/openhab2/.copiedToOH3 ]; then
+    if [ -d /etc/openhab ]; then
+      /bin/cp -Rp /etc/openhab2/. /etc/openhab/
+    else
+      /bin/cp -Rp /etc/openhab2 /etc/openhab
+    fi
+  fi
+  touch /etc/openhab2/.copiedToOH3
+  return 0
+}
+
+
 case "$1" in
   install|upgrade)
     # APT Install or Upgrade
+    if [ "$1" = "install" ]; then
+      copyOH2toOH3
+    fi
     removeCache
     flagVersion
     OH_USER=openhab
@@ -73,6 +98,9 @@ case "$1" in
     ;;
   1|2)
     # RPM Install (1) or Upgrade (2)
+    if [ "$1" = 1 ]; then
+      copyOH2toOH3
+    fi
     flagRestart
     flagVersion
     if [ -x /bin/systemctl ] ; then


### PR DESCRIPTION
Closes #180 (DEFAULT not added as these files are additionally handled by DPKG/RPM, for apt users these files will ask the user what the user wants to do with the changed file, our recommendation should be "yes, change to maintainers version").

For the update to work as `update.lst` intends, the user must update to the latest stable version of openHAB 2.x first.

Tested on .deb and .rpm... repository hosting testing pending.

Signed-off-by: Ben Clark <ben@benjyc.uk>