### PR TITLE
Set file encoding to UTF-8 to prevent problems with umlauts.

### DIFF
--- a/resources/etc/default/openhab
+++ b/resources/etc/default/openhab
@@ -31,7 +31,7 @@
 ##   EXTRA_JAVA_OPTS="-Dgnu.io.rxtx.SerialPorts=/dev/ttyZWAVE:/dev/ttyUSB0:/dev/ttyS0:/dev/ttyS2:/dev/ttyACM0:/dev/ttyAMA0"
 ##   EXTRA_JAVA_OPTS="-Djna.library.path=/lib/arm-linux-gnueabihf/ -Duser.timezone=Europe/Berlin -Dgnu.io.rxtx.SerialPorts=/dev/ttyZWave"
 
-EXTRA_JAVA_OPTS=""
+EXTRA_JAVA_OPTS="-Dfile.encoding=UTF-8"
 
 #########################
 ## OPENHAB DEFAULTS PATHS


### PR DESCRIPTION
There are several issues with umlauts in OH:

https://community.openhab.org/t/solved-umlauts-in-paperui-broken-after-update-from-2-4-to-2-5/88856
https://community.openhab.org/t/umlauts-broken-after-restart-in-oh-2-4/60167

This also applies to OH3. Solution is to start the jvm with UTF-8 encoding.

Signed-off-by: Simon Sielmann <simon.spielman@gmx.de>