### PR TITLE
If appropriate daemon tool exists, issue warning => and exit

### DIFF
--- a/resources/usr/bin/openhab-cli
+++ b/resources/usr/bin/openhab-cli
@@ -173,6 +173,7 @@ case "$option" in
     if [ -x "/bin/systemctl" ] && [ -f "/usr/lib/systemd/system/openhab.service" ]; then
       echo "A systemd service configuration exists..."
       echo "Use 'sudo /bin/systemctl $option openhab.service' to $optionVerb an openHAB service"
+      exit 1
     elif [ -x "/etc/init.d/openhab" ]; then
       echo "An init.d script exists..."
       if [ -x "$(which invoke-rc.d 2>/dev/null)" ]; then
@@ -180,6 +181,7 @@ case "$option" in
       else
         echo "Use 'sudo /etc/init.d/openhab $option' to $optionVerb an openHAB service."
       fi
+      exit 1
     fi
 
     # Then, do as asked with the 'manual' openHAB scripts...


### PR DESCRIPTION
**Background:**
When one issues the `openhab-cli stop` command, the script gives the warning below. However, after the warning, the script continues anyway (as shown below).

```
A systemd service configuration exists...
Use 'sudo /bin/systemctl stop openhab2.service' to stop an openHAB service
..
Stopping any instance of openHAB...
```
**Problem:**
As a consequence the following two things happen one after the other..
- First of all `openhab-cli stop` does stop the OH service
- Then the daemon detects that OH has stopped, -- **_and re-starts OH again!_**

This is clearly stupid, and confusing to users.

**Solution:**
After issuing the warning message, the script should `exit 1` instead of continuing.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>