### PR TITLE
Use EXTRA_JAVA_OPTS also if started manually

### DIFF
--- a/resources/etc/profile.d/openhab.sh
+++ b/resources/etc/profile.d/openhab.sh
@@ -23,6 +23,7 @@ if [ -r ${OPENHAB_CONF}/linux.parameters ]; then
   . ${OPENHAB_CONF}/linux.parameters
 fi
 
+# export these to make them available in the karaf start script
 export OPENHAB_HTTP_PORT
 export OPENHAB_HTTPS_PORT
 export OPENHAB_HOME
@@ -34,3 +35,5 @@ export OPENHAB_BACKUPS
 export OPENHAB_USER
 export OPENHAB_GROUP
 
+export OPENHAB_HTTP_ADDRESS
+export EXTRA_JAVA_OPTS

--- a/resources/replacements/start.sh
+++ b/resources/replacements/start.sh
@@ -4,8 +4,6 @@ echo Launching the openHAB runtime...
 
 if [ -r /etc/profile.d/openhab.sh ]; then
   . /etc/profile.d/openhab.sh
-elif [ -r /etc/default/openhab ]; then
-  . /etc/default/openhab
 fi
 
 if [ ! -z ${OPENHAB_RUNTIME} ]; then


### PR DESCRIPTION
The karaf script is started with `exec` in `start.sh` to let it run in the same shell process, but exec creates a new scope for local variables. So, variables loaded via the `.` command won't be visible to the karaf script. Coincidentally, it works for some config variables as they are exported in `/etc/profile.d/openhab.sh`.

I tried to run the karaf script with the `.` command to keep the variables visible to it, but there's a pretty complicated function in the karaf script to determine the local path. This code fails under some circumstances, e.g. when `start.sh` is ran by `openhab-cli`.

As the `.` command in `start.sh` to `/etc/default/openhab` has no effect, I removed it. The variables in `/etc/default/openhab` are loaded by `/etc/profile.d/openhab.sh` anyway. To make *all* of them visible to the karaf script, I added the missing ones to the exports.

Side note: When started by systemd, all variables in `/etc/default/openhab` are visible to the karaf script as systemd adds all of them to the process' environment.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>